### PR TITLE
fix style for JSON output as code there was a left space before class…

### DIFF
--- a/chrome/css/styles.css
+++ b/chrome/css/styles.css
@@ -1362,6 +1362,7 @@ li .right {
 #response .CodeMirror {
     margin-left: -1px;
     overflow-x: auto;
+    clear: both;
 }
 
 .CodeMirror pre {


### PR DESCRIPTION
fix style for JSON output as code there was a left space before class="CodeMirror CodeMirror-wrap"

Right now it has white space before CodeMirror-wrap